### PR TITLE
accept capital 'y' for confimation

### DIFF
--- a/src/console.rs
+++ b/src/console.rs
@@ -115,7 +115,7 @@ pub fn confirm(message: impl Into<String>) -> bool {
 
     handle.read_exact(&mut ch).expect("Failed to read stdin");
 
-    String::from_utf8_lossy(&ch) == "y"
+    String::from_utf8_lossy(&ch) == "y" || String::from_utf8_lossy(&ch) == "Y"
 }
 
 pub fn input(message: impl Into<String>) -> String {

--- a/src/console.rs
+++ b/src/console.rs
@@ -115,7 +115,7 @@ pub fn confirm(message: impl Into<String>) -> bool {
 
     handle.read_exact(&mut ch).expect("Failed to read stdin");
 
-    String::from_utf8_lossy(&ch) == "y" || String::from_utf8_lossy(&ch) == "Y"
+    String::from_utf8_lossy(&ch).to_lowercase() == "y"
 }
 
 pub fn input(message: impl Into<String>) -> String {


### PR DESCRIPTION
## `lover` quits if you enter a capital 'Y' in confirmation dialogues.
For example: running `lover build` ask for permission to download dependencies.
If you confirm by entering 'Y' `lover` quits.
This patch makes `lover` accept 'y' and 'Y' for confirmation.

Note that I am not a Rust developer, so I have no idea if my code is idiomatic Rust.