### PR TITLE
Fix EXEs not being found in PATH on Windows

### DIFF
--- a/src/actions.rs
+++ b/src/actions.rs
@@ -286,7 +286,12 @@ impl CommandRunner {
                 Some(paths) => {
                     for path in split_paths(&paths) {
                         let file_path = path.join(&self.command);
-                        res.push(file_path);
+                        res.push(file_path.clone());
+
+                        #[cfg(target_family = "windows")]
+                        {
+                            res.push(file_path.with_extension("exe"));
+                        }
                     }
                 },
                 None => ()

--- a/src/config.rs
+++ b/src/config.rs
@@ -125,18 +125,14 @@ impl Software {
 
     fn default_love() -> String {
         #[cfg(target_family = "windows")]
-        return "lovec.exe".to_string();
+        return "lovec".to_string();
 
         #[cfg(target_family = "unix")]
         return "love".to_string();
     }
 
     fn default_luac() -> String {
-        #[cfg(target_family = "windows")]
-        return "luac.exe".to_string();
-
-        #[cfg(not(target_family = "windows"))]
-        return "luac".to_string();
+        "luac".to_string()
     }
 
     fn default_wine() -> String {
@@ -144,7 +140,7 @@ impl Software {
     }
 
     fn default_rcedit() -> String {
-        "rcedit.exe".to_string()
+        "rcedit".to_string()
     }
 
     /*

--- a/src/config.rs
+++ b/src/config.rs
@@ -125,14 +125,18 @@ impl Software {
 
     fn default_love() -> String {
         #[cfg(target_family = "windows")]
-        return "lovec".to_string();
+        return "lovec.exe".to_string();
 
         #[cfg(target_family = "unix")]
         return "love".to_string();
     }
 
     fn default_luac() -> String {
-        "luac".to_string()
+        #[cfg(target_family = "windows")]
+        return "luac.exe".to_string();
+
+        #[cfg(not(target_family = "windows"))]
+        return "luac".to_string();
     }
 
     fn default_wine() -> String {
@@ -140,7 +144,7 @@ impl Software {
     }
 
     fn default_rcedit() -> String {
-        "rcedit".to_string()
+        "rcedit.exe".to_string()
     }
 
     /*


### PR DESCRIPTION
**Summary:**

There was an issue where the code attempted to check if luac was a valid file by calling .is_file() on each defined path without specifying a file extension. On Windows, this would fail since file require an extension.
I've added .exe to the default software paths, ensuring the check works correctly on Windows systems.

**Notes:**

This fix has only been briefly tested on Windows. I'm not sure if the changes work on Unix systems.